### PR TITLE
Prevent invites after event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -116,7 +116,7 @@ private
   end
 
   def check_event_past
-    unless Time.now < @event.due_at
+    unless @event.is_past?
       flash[:error] = "Can't edit an event that has already happened."
       redirect_to event_path(@event)
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -399,6 +399,10 @@ class Event < ActiveRecord::Base
     paid_members.count > 0
   end
 
+  def is_past?
+    Time.now > self.due_at
+  end
+
 private
   def clear_amounts
     if division_type != DivisionType::SPLIT


### PR DESCRIPTION
Status: Ready for Review, at the moment disallows access to edit/update page after event has passed.

From issue #234
